### PR TITLE
Limits key length to memcached's max key length

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,52 @@ until one is found that can handle the request. If no matching authenticators ar
 reports that the request is not authorized, the optional unauthorized response is returned. Otherwise, the request
 continues in the chain.
 
-The following authenticators are included:
+### Authenticators
 
-* Auth0: Authorizes the request with Auth0 and includes the user's information in the "x-user" header
+Authenticators provide an interface to 3rd party authentication services.
+
+#### Auth0
+
+Authenticates the user's JWT and adds the user's information in the `x-user` header.
+
+```clojure
+(ns myapp.core
+  (:require [ring-gatekeeper.authenticators.auth0 :as auth0]))
+
+(def my-authenticator (auth0/new-authenticator {:can-handle-request-fn (constantly true)
+                                                :client-id "client-id"
+                                                :client-secret "client-secret"
+                                                :subdomain "subdomain"}))
+```
+
+Options:
+
+* `can-handle-request-fn`: Determines if the authenticator can handle a particular request
+* `client-id`: Auth0 client id
+* `client-secret`: Auth0 client secret
+* `subdomain`: Auth0 subdomain
+* `cache`: Cache for storing user info
+
+### Caches
+
+Caches are used by various authenticators to improve performance.
+
+#### Memcached
+
+```clojure
+(ns myapp.core
+  (:require [ring-gatekeeper.cache.memcached :as gate-cache]
+            [clojurewerkz.spyglass.client :as memcached-client])
+
+(def client (memcached-client/text-connection "localhost:11211"))
+(def auth-cache (gate-cache/new-cache client {:key-prefix "user-info-"
+                                              :expire-sec 2400}))
+```
+
+Options:
+
+* `key-prefix`: Prefix added on keys to prevent collisions
+* `expire-sec`: How long key should stay in the cache
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ring-gatekeeper "0.1.2"
+(defproject ring-gatekeeper "0.1.3-SNAPSHOT"
   :description "Authentication middleware"
   :url "https://github.com/FundingCircle/ring-gatekeeper"
   :license {:name "BSD 3-clause"
@@ -11,4 +11,4 @@
                  [clj-http "1.0.1"]
                  [clojurewerkz/spyglass "1.0.0"]
                  [com.taoensso/timbre "3.2.1"]
-                 [jerks-whistling-tunes "0.1.1"]])
+                 [jerks-whistling-tunes "0.1.2"]])

--- a/src/ring_gatekeeper/cache/core.clj
+++ b/src/ring_gatekeeper/cache/core.clj
@@ -1,8 +1,9 @@
-(ns ring-gatekeeper.cache.core)
+(ns ring-gatekeeper.cache.core
+  (:refer-clojure :exclude [get set]))
 
 (defprotocol Cache
   "Caches values"
   (get [this key]
        "Retrieves the cached value for the given key")
-  (set [this key expire value]
+  (set [this key value]
        "Sets the cached value for the given key"))

--- a/src/ring_gatekeeper/cache/memcached.clj
+++ b/src/ring_gatekeeper/cache/memcached.clj
@@ -1,15 +1,33 @@
 (ns ring-gatekeeper.cache.memcached
-  (:require [clojurewerkz.spyglass.client :as memcached-client]
+  (:refer-clojure :exclude [get set])
+  (:require [clojurewerkz.spyglass.client :as mem-client]
             [ring-gatekeeper.cache.core :as core]))
 
-(deftype Memcached [client]
+(def ^:private default-key-prefix "tokeninfo-")
+(def ^:private default-expire-sec 300)
+
+(defn- build-key [prefix key]
+  (str prefix key))
+
+(defn- get-prefix [opts]
+  (clojure.core/get opts :key-prefix default-key-prefix))
+
+(defn- get-expire-sec [opts]
+  (clojure.core/get opts :expire-sec default-expire-sec))
+
+(deftype Memcached [client opts]
   core/Cache
 
   (get [this key]
-    (memcached-client/get client key))
+    (mem-client/get client
+                    (build-key (get-prefix opts) key)))
 
-  (set [this key expire value]
-    (memcached-client/set client key expire value)))
+  (set [this key value]
+    (mem-client/set client
+                    (build-key (get-prefix opts) key)
+                    (get-expire-sec opts)
+                    value)))
 
-(defn new-cache [client]
-  (Memcached. client))
+(defn new-cache
+  ([client] (new-cache client {}))
+  ([client opts] (Memcached. client opts)))

--- a/src/ring_gatekeeper/cache/noop.clj
+++ b/src/ring_gatekeeper/cache/noop.clj
@@ -7,7 +7,7 @@
   (get [this key]
     nil)
 
-  (set [this key expire value]
+  (set [this key value]
     nil))
 
 (defn new-cache []


### PR DESCRIPTION
@ottbot @dbolson 

## Issue

After a user is authenticated we try to grab their information from the cache using their auth token. Memcached blows up because the tokens (300+ characters) exceed the max length (250 characters).

## Solution

Truncate the key after 250 characters to prevent exceeding the max key length. Another solution would be to hash the user token, but I'm not sure if that would result in fewer collisions.