### PR TITLE
Fix CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: clojure:lein-alpine
+      - image: redis:alpine
+    steps:
+      - checkout
+      - restore_cache:
+          key: ring-gatekeeper-{{ checksum "project.clj" }}
+      - run: lein deps
+      - save_cache:
+          key: ring-gatekeeper-{{ checksum "project.clj" }}
+          paths:
+            - ~/.m2
+      - run: lein spec
+    working_directory: ~/ring-gatekeeper

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  override:
-    - lein spec


### PR DESCRIPTION
💁 This change migrates the CircleCI job configuration to 2.0 format and fixes the build by spinning up a Redis server.