### PR TITLE
[FPT-796] Add Support for Login on CE environments

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fundingcircle/ring-gatekeeper "0.3.2-SNAPSHOT"
+(defproject fundingcircle/ring-gatekeeper "0.3.3-SNAPSHOT"
   :description "Authentication middleware"
   :url "https://github.com/FundingCircle/ring-gatekeeper"
   :license {:name "BSD 3-clause"

--- a/src/ring_gatekeeper/authenticators/auth0.clj
+++ b/src/ring_gatekeeper/authenticators/auth0.clj
@@ -8,6 +8,9 @@
             [jerks-whistling-tunes.utils :refer [decode-base-64]]))
 
 (defn- auth0-token-info-url [subdomain]
+  (str "https://" subdomain ".auth0.com/tokeninfo"))
+
+(defn- auth0-user-info-url [subdomain]
   (str "https://" subdomain ".auth0.com/userinfo"))
 
 ; Key must be unique per user per application
@@ -16,16 +19,20 @@
 (defn- build-cache-key [{:keys [sub aud]}]
   (str aud "-" sub))
 
-(defn- get-auth0-user-info-response [cache id-token subdomain claims]
-  (prn "user info params" {:throw-exceptions false
-                           :content-type :json
-                           :headers {:authorization (str "Bearer " id-token)}})
-  (let [response (client/post (auth0-token-info-url subdomain)
-                              {:throw-exceptions false
-                               :content-type :json
-                               :headers {:authorization (str "Bearer " id-token)}})
+(defn- prepare-user-info-options [token use-access-token?]
+  (cond-> {:throw-exceptions false
+           :content-type :json}
+    use-access-token? (assoc :headers {:authorization (str "Bearer " token)})
+    (not use-access-token?) (assoc :body (json/write-str {:id_token token}))))
+
+(defn- prepare-url [subdomain use-access-token?]
+  (if use-access-token?
+    (auth0-user-info-url subdomain)
+    (auth0-token-info-url subdomain)))
+
+(defn- get-auth0-user-info-response [cache claims url options ]
+  (let [response (client/post url options)
         {:keys [body status]} response]
-    (prn "###### response" response)
     (if (= 200 status)
       (do
         (.set cache
@@ -46,6 +53,23 @@
     (or (extract-token-from-auth-header auth-header)
         (get-in request [:params "id-token"]))))
 
+(defn- validate-jwt-token [token client-id client-secret]
+  (jwt/validate token
+                (jwt/signature (hs256 client-secret))
+                (jwt/aud client-id)
+                jwt/exp))
+
+(defn- get-claims [token client-id client-secret use-access-token?]
+  (if use-access-token? 
+    {:aud client-id
+     :sub token}
+    (validate-jwt-token token client-id client-secret)))
+
+(defn- get-user-info [cache token subdomain claims use-access-token?]
+    (let [url (prepare-url subdomain use-access-token?)
+          options (prepare-user-info-options token use-access-token?)]
+      (get-auth0-user-info-response cache claims url options)))
+
 (def default-cache (noop-cache/new-cache))
 
 (defrecord Auth0Authenticator [client-secret opts]
@@ -55,14 +79,13 @@
     ((:can-handle-request-fn opts) request))
 
   (authenticate [this request]
-    (let [{:keys [client-id subdomain]} opts
+    (let [{:keys [client-id subdomain use-access-token?]
+           :or {use-access-token? false}} opts
           cache (get opts :cache default-cache)
           token (extract-token request)]
-      (if-let [claims true]
-        (do
-          (prn "############## claims:" claims)
-          (or (get-cached-user-info-response cache claims)
-              (get-auth0-user-info-response cache token subdomain claims)))
+      (if-let [claims (get-claims token client-id client-secret use-access-token?)]
+        (or (get-cached-user-info-response cache claims)
+            (get-user-info cache token subdomain claims use-access-token?))
         nil))))
 
 (defn new-authenticator [opts]

--- a/src/ring_gatekeeper/core.clj
+++ b/src/ring_gatekeeper/core.clj
@@ -23,15 +23,8 @@
   (fn [request]
     (if-let [authenticator (find-first #(.handle-request? % request) authenticators)]
       (if-let [user-info (.authenticate authenticator request)]
-        (do
-          (prn "user-info: " user-info)
-          (handler (assoc-in request
-                             [:headers "x-user"]
-                             user-info)))
-        (do
-          (prn "#### failed 1")
-          (handler (strip-user request))))
-      
-      (do 
-        (prn "### failed 2")
-        (handler (strip-user request))))))
+        (handler (assoc-in request
+                           [:headers "x-user"]
+                           user-info))
+        (handler (strip-user request)))
+      (handler (strip-user request)))))

--- a/src/ring_gatekeeper/core.clj
+++ b/src/ring_gatekeeper/core.clj
@@ -23,8 +23,15 @@
   (fn [request]
     (if-let [authenticator (find-first #(.handle-request? % request) authenticators)]
       (if-let [user-info (.authenticate authenticator request)]
-        (handler (assoc-in request
-                           [:headers "x-user"]
-                           user-info))
-        (handler (strip-user request)))
-      (handler (strip-user request)))))
+        (do
+          (prn "user-info: " user-info)
+          (handler (assoc-in request
+                             [:headers "x-user"]
+                             user-info)))
+        (do
+          (prn "#### failed 1")
+          (handler (strip-user request))))
+      
+      (do 
+        (prn "### failed 2")
+        (handler (strip-user request))))))


### PR DESCRIPTION
Todo:

- [x] Add support to get the profile using `/userinfo` and an `access-token`
- [x] Code cleanup, remove `prn` calls
- [x] Add support for option to use `jwt` (also known as id-token) or `access-token`